### PR TITLE
Add EXIT_RSETH_AGENT role for Aleph and ETH Alpha Fund

### DIFF
--- a/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/members.ts
+++ b/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/members.ts
@@ -1,0 +1,1 @@
+export default []

--- a/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/members.ts
+++ b/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/members.ts
@@ -1,1 +1,4 @@
-export default [0x172fbc0fe00fe28f57fc68fea8aee7a449ce1dd6,0xd04189b1ad8ae82c1d1b90983671786377edc216] // [rETH,stETH]
+export default [
+  0x172fbc0fe00fe28f57fc68fea8aee7a449ce1dd6,
+  0xd04189b1ad8ae82c1d1b90983671786377edc216,
+] // [rETH,stETH]

--- a/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/members.ts
+++ b/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/members.ts
@@ -1,1 +1,1 @@
-export default []
+export default [0x172fbc0fe00fe28f57fc68fea8aee7a449ce1dd6,0xd04189b1ad8ae82c1d1b90983671786377edc216] // [rETH,stETH]

--- a/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/permissions/_actions.ts
+++ b/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/permissions/_actions.ts
@@ -1,0 +1,1 @@
+export default []

--- a/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/permissions/calls.ts
+++ b/clients/aleph/mainnet/roles/EXIT_RSETH_AGENT/permissions/calls.ts
@@ -1,0 +1,22 @@
+import { c } from "zodiac-roles-sdk"
+import { allow } from "zodiac-roles-sdk/kit"
+import { eAddress } from "@/addresses"
+import { ETHx, rsETH, stETH } from "@/addresses/eth"
+import { contracts } from "@/contracts"
+import { allowErc20Approve } from "@/helpers"
+import { PermissionList } from "@/types"
+import { Parameters } from "../../../parameters"
+
+export default (parameters: Parameters) =>
+  [
+    // Aave v3 - Withdraw rsETH to the avatar Safe
+    allow.mainnet.aaveV3.poolCoreV3.withdraw(rsETH, undefined, c.avatar),
+
+    // Kelp - Approve rsETH to the WithdrawalManager
+    allowErc20Approve([rsETH], [contracts.mainnet.kelp.lrtWithdrawalManager]),
+
+    // Kelp - Initiate withdrawal redeeming for ETH, ETHx or stETH
+    allow.mainnet.kelp.lrtWithdrawalManager.initiateWithdrawal(
+      c.or(eAddress, ETHx, stETH)
+    ),
+  ] satisfies PermissionList

--- a/clients/eth-alpha-fund/mainnet/roles/EXIT_RSETH_AGENT/members.ts
+++ b/clients/eth-alpha-fund/mainnet/roles/EXIT_RSETH_AGENT/members.ts
@@ -1,0 +1,1 @@
+export default []

--- a/clients/eth-alpha-fund/mainnet/roles/EXIT_RSETH_AGENT/members.ts
+++ b/clients/eth-alpha-fund/mainnet/roles/EXIT_RSETH_AGENT/members.ts
@@ -1,1 +1,1 @@
-export default []
+export default [0xe1da89af9fc3a6f8c179ee84967e118add4eb6c2]

--- a/clients/eth-alpha-fund/mainnet/roles/EXIT_RSETH_AGENT/permissions/_actions.ts
+++ b/clients/eth-alpha-fund/mainnet/roles/EXIT_RSETH_AGENT/permissions/_actions.ts
@@ -1,0 +1,1 @@
+export default []

--- a/clients/eth-alpha-fund/mainnet/roles/EXIT_RSETH_AGENT/permissions/calls.ts
+++ b/clients/eth-alpha-fund/mainnet/roles/EXIT_RSETH_AGENT/permissions/calls.ts
@@ -1,0 +1,22 @@
+import { c } from "zodiac-roles-sdk"
+import { allow } from "zodiac-roles-sdk/kit"
+import { eAddress } from "@/addresses"
+import { ETHx, rsETH, stETH } from "@/addresses/eth"
+import { contracts } from "@/contracts"
+import { allowErc20Approve } from "@/helpers"
+import { PermissionList } from "@/types"
+import { Parameters } from "../../../parameters"
+
+export default (parameters: Parameters) =>
+  [
+    // Aave v3 - Withdraw rsETH to the avatar Safe
+    allow.mainnet.aaveV3.poolCoreV3.withdraw(rsETH, undefined, c.avatar),
+
+    // Kelp - Approve rsETH to the WithdrawalManager
+    allowErc20Approve([rsETH], [contracts.mainnet.kelp.lrtWithdrawalManager]),
+
+    // Kelp - Initiate withdrawal redeeming for ETH, ETHx or stETH
+    allow.mainnet.kelp.lrtWithdrawalManager.initiateWithdrawal(
+      c.or(eAddress, ETHx, stETH)
+    ),
+  ] satisfies PermissionList


### PR DESCRIPTION
## Summary

- Creates a new `EXIT_RSETH_AGENT` role (bytes32 `0x455849545f52534554485f4147454e5400000000000000000000000000000000`) on the `aleph` and `eth-alpha-fund` mainnet configs.
- Role allows the three-leg rsETH unwind flow:
  1. `aaveV3.poolCoreV3.withdraw(rsETH, _, c.avatar)` — burns aRsETH, transfers rsETH to the avatar Safe.
  2. `rsETH.approve(kelp.lrtWithdrawalManager, _)` — exact-allowance approve to the Kelp WithdrawalManager.
  3. `kelp.lrtWithdrawalManager.initiateWithdrawal(c.or(eAddress, ETHx, stETH))` — initiate withdrawal redeeming for ETH, ETHx, or stETH.
- Targets the subroles modifier instances: `aleph/sub_reth`, `aleph/sub_steth`, `eth-alpha-fund/sub_prod`.

## Notes

- `members.ts` is left as `export default []` — the agent EOA needs to be added before applying.
- `referralId` is unconstrained on `initiateWithdrawal` (consistent with the existing pattern in `clients/gnosis-dao/lending-markets/mainnet/roles/MANAGER/permissions/calls.ts`).

## Test plan

- [ ] Add the EXIT_RSETH_AGENT agent EOA to each client's `members.ts`
- [ ] `yarn apply aleph mainnet/sub_reth EXIT_RSETH_AGENT` — review diff in Zodiac Roles app
- [ ] `yarn apply aleph mainnet/sub_steth EXIT_RSETH_AGENT` — review diff
- [ ] `yarn apply eth-alpha-fund mainnet/sub_prod EXIT_RSETH_AGENT` — review diff
- [ ] Dry-run the 3-leg flow on a fork against each avatar Safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)