### PR TITLE
aleph: add MANAGER mainnet positions (sGHO, Kelp EIGEN claim, Morpho Yield, Spark, Stakewise, CoW)

### DIFF
--- a/clients/aleph/mainnet/roles/MANAGER/permissions/_actions.ts
+++ b/clients/aleph/mainnet/roles/MANAGER/permissions/_actions.ts
@@ -2,11 +2,14 @@ import { allow as allowAction } from "defi-kit/eth"
 import {
   AURA,
   BAL,
+  EIGEN,
   ETHPlus,
   ezETH,
   GEAR,
+  GHO,
   KING,
   MORPHO,
+  osETH,
   rETH,
   RPL,
   rsETH,
@@ -36,6 +39,8 @@ export default (parameters: Parameters) => [
   // Aave v3 Core Market - Deposit wstETH
   allowAction.aave_v3.deposit({ market: "Core", targets: ["wstETH"] }),
 
+  // Aave v3 Core Market - Borrow GHO
+  allowAction.aave_v3.borrow({ market: "Core", targets: ["GHO"] }),
   // Aave v3 Core Market - Borrow WETH
   allowAction.aave_v3.borrow({ market: "Core", targets: ["WETH"] }),
 
@@ -54,17 +59,20 @@ export default (parameters: Parameters) => [
   // Convex - WETH/weETH
   allowAction.convex.deposit({ targets: ["355"] }),
 
-  // CowSwap - [AURA, BAL, ETHPlus, ezETH, GEAR, KING, MORPHO, rETH, RPL, rsETH, stETH, USDC, weETH, WETH, wstETH] ->
-  // [ETHPlus, ezETH, rETH, rsETH, stETH, weETH, WETH, wstETH]
+  // CowSwap - [AURA, BAL, EIGEN, ETHPlus, ezETH, GEAR, GHO, KING, MORPHO, osETH, rETH, RPL, rsETH, stETH, USDC, weETH, WETH, wstETH] ->
+  // [ETHPlus, ezETH, osETH, rETH, rsETH, stETH, weETH, WETH, wstETH]
   allowAction.cowswap.swap({
     sell: [
       AURA,
       BAL,
+      EIGEN,
       ETHPlus,
       ezETH,
       GEAR,
+      GHO,
       KING,
       MORPHO,
+      osETH,
       rETH,
       RPL,
       rsETH,
@@ -74,7 +82,7 @@ export default (parameters: Parameters) => [
       WETH,
       wstETH,
     ],
-    buy: [ETHPlus, ezETH, rETH, rsETH, stETH, weETH, WETH, wstETH],
+    buy: [ETHPlus, ezETH, osETH, rETH, rsETH, stETH, weETH, WETH, wstETH],
   }),
 
   // Gearbox - ETH v3 - Curator: kpk
@@ -143,14 +151,27 @@ export default (parameters: Parameters) => [
   allowAction.morphoVaults.deposit({
     targets: [morpho.kpkEthPrimeV2],
   }),
+  // Morpho Vault - kpk ETH Yield v2
+  allowAction.morphoVaults.deposit({
+    targets: [morpho.kpkEthYieldV2],
+  }),
 
   // Rocket Pool
   allowAction.rocket_pool.deposit(),
 
   // Spark - Deposit rETH
   allowAction.spark.deposit({ targets: ["rETH"] }),
+  // Spark - Deposit weETH
+  allowAction.spark.deposit({ targets: ["weETH"] }),
+  // Spark - Deposit WETH
+  allowAction.spark.deposit({ targets: ["WETH"] }),
   // Spark - Deposit wstETH
   allowAction.spark.deposit({ targets: ["wstETH"] }),
   // Spark - Borrow WETH
   allowAction.spark.borrow({ targets: ["WETH"] }),
+
+  // Stakewise v3 - Stake ETH
+  allowAction.stakewise_v3.stake({
+    targets: ["0x15639e82d2072fa510e5d2b5f0db361c823bcad3"],
+  }),
 ]

--- a/clients/aleph/mainnet/roles/MANAGER/permissions/calls.ts
+++ b/clients/aleph/mainnet/roles/MANAGER/permissions/calls.ts
@@ -3,6 +3,7 @@ import { allow } from "zodiac-roles-sdk/kit"
 import { contracts } from "@/contracts"
 import {
   eETH,
+  GHO,
   rETH,
   rsETH,
   stETH,
@@ -86,6 +87,12 @@ export default (parameters: Parameters) =>
 
     // Aave Prime v3 - Enable/Disable E-Mode
     allow.mainnet.aaveV3.poolPrimeV3.setUserEMode(),
+
+    // Aave v3 - sGHO (Savings GHO)
+    allowErc20Approve([GHO], [contracts.mainnet.aaveV3.sGho]),
+    allow.mainnet.aaveV3.sGho.deposit(undefined, c.avatar),
+    allow.mainnet.aaveV3.sGho.withdraw(undefined, c.avatar, c.avatar),
+    allow.mainnet.aaveV3.sGho.redeem(undefined, c.avatar, c.avatar),
 
     // Aura - Aave Boosted WETH/rETH
     allowErc20Approve(
@@ -193,6 +200,8 @@ export default (parameters: Parameters) =>
     allow.mainnet.kelp.lrtWithdrawalManager.instantWithdrawal(
       c.or(eAddress, stETH)
     ),
+    // Kelp - Claim EIGEN rewards (Merkl)
+    allow.mainnet.kelp.merklDistributor.claim(undefined, c.avatar),
 
     // Merkl - Rewards
     allow.mainnet.merkl.angleDistributor.claim(


### PR DESCRIPTION
## Permission Change Request

| Field | Value |
| --- | --- |
| **Client** | aleph |
| **Network** | mainnet |
| **Role** | MANAGER |
| **Avatar Safes** | `0xdE53bCdA6527D2aa15Ec733352C8d393C2E0eC99` (rETH mandate) · `0xEec0048ef14b44B1DBEc1Cf0f7c9c9E31F3d42CA` (stETH mandate) |
| **Type** | New |

Both mandate Safes share the single `roles/MANAGER` policy (instances differ only by `avatar`), so this one change applies to both.

### Actions added

**DeFi-Kit actions — `_actions.ts`**

- **Aave v3 Core** — Borrow GHO
- **Morpho** — deposit into the **kpk ETH Yield v2** vault (`0x5dbf760b4fd0cDdDe0366b33aEb338b2A6d77725`, `morpho.kpkEthYieldV2`)
- **Spark** — Supply weETH
- **Spark** — Supply WETH
- **Stakewise v3** — Stake ETH (vault `0x15639e82d2072fa510e5d2b5f0db361c823bcad3`)
- **CoW Swap** — added **EIGEN**, **GHO**, **osETH** to the sell basket and **osETH** to the buy basket (osETH is two-way)

**Ad-hoc (typed-preset) — `calls.ts`**

- **Aave v3 sGHO (Savings GHO)** — ERC-4626 vault (`0xE1753F2e00940cC31213dd92013cF019DFE4ca1d`). Scoped: `GHO` approve to the vault, plus `deposit` / `withdraw` / `redeem` with `receiver`/`owner` pinned to the avatar Safe. `mint` intentionally not whitelisted.
- **Kelp — Claim EIGEN** — Merkl distributor (`0x9bB6d4b928645EdA8f9C019495695BA98969eFF1`). Cumulative Merkle distributor `claim(index, account, cumulativeAmount, merkleProof)` with `account` pinned to the avatar Safe; index/amount/proof left open (set per-claim by the Merkl/Kelp API).

### Already present (no change)

- **Aave v3 Core — Supply osETH** was already whitelisted in this policy.

> ⚠️ **Security review — two hand-scoped contracts not in DeFi-Kit.** Both **sGHO** (`aaveV3.sGho`) and the **Kelp Merkl distributor** (`kelp.merklDistributor`) were scoped by hand against their verified on-chain ABIs. They need Ops Engineering security review of the scoping before execution. Both are candidates for proper DeFi-Kit integration.

### Validation

- `yarn check:types` — passes (only pre-existing errors in untracked local helper scripts)
- `yarn fix:prettier` — clean (no changes to the touched files)

> The transaction payload from `yarn apply` still needs **Pilot Extension / Tenderly** testing before execution, for each mandate Safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)