### PR TITLE
usd-alpha-fund: add Aave sGHO (Savings GHO) to MANAGER mainnet

### DIFF
--- a/clients/usd-alpha-fund/mainnet/roles/MANAGER/permissions/calls.ts
+++ b/clients/usd-alpha-fund/mainnet/roles/MANAGER/permissions/calls.ts
@@ -25,6 +25,12 @@ export default (parameters: Parameters) =>
      * Protocols
      *********************************************/
 
+    // Aave v3 - sGHO (Savings GHO)
+    allowErc20Approve([GHO], [contracts.mainnet.aaveV3.sGho]),
+    allow.mainnet.aaveV3.sGho.deposit(undefined, c.avatar),
+    allow.mainnet.aaveV3.sGho.withdraw(undefined, c.avatar, c.avatar),
+    allow.mainnet.aaveV3.sGho.redeem(undefined, c.avatar, c.avatar),
+
     // Balancer v3 - Aave Boosted USDT/GHO/USDC
     allowErc20Approve([GHO, USDC, USDT], [contracts.mainnet.uniswap.permit2]),
     allow.mainnet.uniswap.permit2.approve(


### PR DESCRIPTION
## Permission Change Request

| Field | Value |
| --- | --- |
| **Client** | usd-alpha-fund |
| **Network** | mainnet |
| **Role** | MANAGER |
| **Avatar Safe** | `0x38F6a1B46144fAEe6a6D9F79D8dE264C18e23848` |
| **Type** | New |

This PUR requested three items. The preliminary check found two of them were already in the policy, so only one is actually added here.

### Already in the policy (no change)

- **Morpho — KPK USDC Yield Vault** (`kpkUsdcYieldV2`, `0xD5cCe260E7a755DDf0Fb9cdF06443d593AaeaA13`) — already whitelisted via `morphoVaults.deposit` in `_actions.ts`.
- **Morpho — KPK USDT Prime Vault** (`kpkUsdtPrimeV2`, `0x870F0BF29A25A40E7CC087cD5C53e70C11F2C8A8`) — already whitelisted via `morphoVaults.deposit` in `_actions.ts`.
- **Aave Safety Module — Stake GHO** (legacy `stkGHO`, `0x1a88…`) — already present via `aave_v3.stake({ targets: ["GHO"] })`. Left untouched; this is a *different* contract from the new sGHO below.

### Added (`calls.ts`)

- **Aave v3 sGHO (Savings GHO)** — new ERC-4626 vault (`0xE1753F2e00940cC31213dd92013cF019DFE4ca1d`). Scoped:
  - `GHO` approve to the vault
  - `deposit` / `withdraw` / `redeem` with `receiver`/`owner` pinned to the avatar Safe
  - `mint` intentionally not whitelisted

> ⚠️ **Security review — hand-scoped contract not in DeFi-Kit.** sGHO (`aaveV3.sGho`) was scoped by hand against its verified on-chain ABI and needs Ops Engineering security review of the scoping before execution. It is a candidate for proper DeFi-Kit integration.

### Validation

- `yarn check:types` — passes (only pre-existing errors in untracked local helper scripts)
- `yarn fix:prettier` — clean

> The transaction payload from `yarn apply` still needs **Pilot Extension / Tenderly** testing before execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)