### PR TITLE
usd-alpha-fund: remove Morpho USDC/PT-USDe-11DEC2025 market from MANAGER base

### DIFF
--- a/clients/usd-alpha-fund/base/roles/MANAGER/permissions/_actions.ts
+++ b/clients/usd-alpha-fund/base/roles/MANAGER/permissions/_actions.ts
@@ -24,12 +24,6 @@ export default (parameters: Parameters) => [
       "0x1c21c59df9db44bf6f645d854ee710a8ca17b479451447e9f56758aee10a2fad",
     ],
   }),
-  // Morpho Market - USDC/PT-USDe-11DEC2025 - id: 0xafa2d80fcc3aa58419dd8c62b57087384bc35de27d70de9c91525276f2b2fd6e
-  allowAction.morphoMarkets.deposit({
-    targets: [
-      "0xafa2d80fcc3aa58419dd8c62b57087384bc35de27d70de9c91525276f2b2fd6e",
-    ],
-  }),
 
   /*********************************************
    * Bridges


### PR DESCRIPTION
## Permission Change Request

| Field | Value |
| --- | --- |
| **Client** | usd-alpha-fund |
| **Network** | base |
| **Role** | MANAGER |
| **Avatar Safe** | `0x38F6a1B46144fAEe6a6D9F79D8dE264C18e23848` |
| **Type** | Remove |

### Removed (`_actions.ts`)

- **Morpho Market — USDC/PT-USDe-11DEC2025** (id `0xafa2d80fcc3aa58419dd8c62b57087384bc35de27d70de9c91525276f2b2fd6e`) — removed the `morphoMarkets.deposit` permission for this market.

### Unchanged (no change)

- **Morpho Market — USDC/cbBTC** (`0x9103c3b4…191836`) — still whitelisted.
- **Morpho Market — USDC/cbETH** (`0x1c21c59d…0a2fad`) — still whitelisted.
- All other positions, bridges, and swaps untouched.

### Validation

- `yarn check:types` — passes (only pre-existing errors in untracked local helper scripts).
- `prettier --check` on the touched file — clean.
- `yarn apply:export usd-alpha-fund base/main_prod MANAGER` — compiled. Payload re-scopes the Morpho deposit functions to drop the PT-USDe market (1 annotation `post` + 2 `scopeFunction`); it does not revoke the other markets.

> Two base instances (`main_prod`, `main_stage`) share this single policy, so the removal applies to both. Validated against `main_prod`.

> The transaction payload from `yarn apply` still needs **Pilot Extension / Tenderly** testing before execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
