### PR TITLE
feat(usd-alpha-fund): DISASSEMBLER role — withdraw-only permissions for position-exit agents

### DIFF
--- a/clients/usd-alpha-fund/mainnet/roles/DISASSEMBLER/members.ts
+++ b/clients/usd-alpha-fund/mainnet/roles/DISASSEMBLER/members.ts
@@ -1,0 +1,1 @@
+export default ["0x1c79b0fd187ef5f534766a1dac8c7a9257fcd783"]

--- a/clients/usd-alpha-fund/mainnet/roles/DISASSEMBLER/permissions/_actions.ts
+++ b/clients/usd-alpha-fund/mainnet/roles/DISASSEMBLER/permissions/_actions.ts
@@ -1,0 +1,1 @@
+export default []

--- a/clients/usd-alpha-fund/mainnet/roles/DISASSEMBLER/permissions/calls.ts
+++ b/clients/usd-alpha-fund/mainnet/roles/DISASSEMBLER/permissions/calls.ts
@@ -1,0 +1,31 @@
+import { c } from "zodiac-roles-sdk"
+import { allow } from "zodiac-roles-sdk/kit"
+import { USDC, USDT, morpho } from "@/addresses/eth"
+import { PermissionList } from "@/types"
+
+export default () =>
+  [
+    // Aave v3 Core Market - Withdraw USDC to the avatar Safe
+    allow.mainnet.aaveV3.poolCoreV3.withdraw(USDC, undefined, c.avatar),
+    // Aave v3 Core Market - Withdraw USDT to the avatar Safe
+    allow.mainnet.aaveV3.poolCoreV3.withdraw(USDT, undefined, c.avatar),
+
+    // Morpho Vault - kpk USDC Prime v2 - Withdraw USDC to the avatar Safe
+    {
+      ...allow.mainnet.morpho.vault.withdraw(undefined, c.avatar, c.avatar),
+      targetAddress: morpho.kpkUsdcPrimeV2,
+    },
+    // Morpho Vault - kpk USDC Yield v2 - Withdraw USDC to the avatar Safe
+    {
+      ...allow.mainnet.morpho.vault.withdraw(undefined, c.avatar, c.avatar),
+      targetAddress: morpho.kpkUsdcYieldV2,
+    },
+    // Morpho Vault - kpk USDT Prime v2 - Withdraw USDT to the avatar Safe
+    {
+      ...allow.mainnet.morpho.vault.withdraw(undefined, c.avatar, c.avatar),
+      targetAddress: morpho.kpkUsdtPrimeV2,
+    },
+
+    // Spark - Withdraw USDS from sUSDS to the avatar Safe
+    allow.mainnet.spark.sUsds.withdraw(undefined, c.avatar, c.avatar),
+  ] satisfies PermissionList


### PR DESCRIPTION
## Permission Change Request — mainnet (sub_stage)

| Field           | Value                                                        |
| --------------- | ------------------------------------------------------------ |
| **Client**      | usd-alpha-fund                                               |
| **Network**     | mainnet                                                      |
| **Instance**    | sub_stage (OIV USD Stage)                                    |
| **Role**        | DISASSEMBLER (new role)                                      |
| **Avatar Safe** | `0x5298ac59f2746fAce715AAc2e8aD489cA434b698`                 |
| **Roles Mod**   | `0xE80edC85F8f0E28a879b3c91Efd8A04C6731BFee`                 |
| **Type**        | New                                                          |

New withdraw-only role for the on-demand `position_exit` kpk-agents automation
(karpatkey/kpk-agents#719): one agent instance per position, each submitting a
single Roles-executed withdraw of `min(position balance, protocol liquidity)`
into the avatar Safe. Deposits, swaps, and approvals are deliberately excluded.

### Actions added

**Ad-hoc (typed-preset) — `calls.ts`** (all recipients/owners pinned to `c.avatar`)

- **Aave v3 Core** — `pool.withdraw(asset, amount, to)` with `asset` ∈ {USDC, USDT}, `to` = avatar Safe. Covers aUSDC `0x98C23E9d…6F5c` and aUSDT `0x23878914…086a` positions.
- **Morpho Vault v2** — `withdraw(assets, receiver, owner)` with `receiver` = `owner` = avatar Safe, on:
  - kpk USDC Prime v2 `0x4Ef53d2cAa51C447fdFEEedee8F07FD1962C9ee6`
  - kpk USDC Yield v2 `0xD5cCe260E7a755DDf0Fb9cdF06443d593AaeaA13`
  - kpk USDT Prime v2 `0x870F0BF29A25A40E7CC087cD5C53e70C11F2C8A8`
- **Spark / Sky** — sUSDS `0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD` `withdraw(assets, receiver, owner)` with `receiver` = `owner` = avatar Safe (USDS out).

**DeFi-Kit actions — `_actions.ts`** — none (empty).

### Members

- `0x1c79b0fd187ef5f534766a1dac8c7a9257fcd783` (existing stage-USD agent EOA). Note: the apply payload scopes permissions only — the `assignRoles` membership grant for this EOA on the DISASSEMBLER role key must be executed alongside it.

### Address / dependency changes

- None — all targets already exist in `@/addresses/eth` / the eth-sdk registry.

### Validation

- `yarn check:types` — passes (only a pre-existing error in `clients/cow/main/mainnet/roles/MANAGER/permissions/_actions.ts`).
- `yarn apply:export usd-alpha-fund mainnet/sub_stage DISASSEMBLER` — payload: 5 `scopeTarget` + 5 `scopeFunction`, selectors `0x69328dec` (Aave pool `withdraw`) and `0xb460af94` (ERC4626 `withdraw`) only.
- Permissions diff: https://roles.gnosisguild.org/eth:0xE80edC85F8f0E28a879b3c91Efd8A04C6731BFee/roles/DISASSEMBLER/diff/TBET08oRfiXYKVaZ1QNhBUYxw7T4w87AkcOze7ilhCs

> The `yarn apply` payload still needs **Pilot Extension / Tenderly** testing before execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
